### PR TITLE
fix 高版本flutter(2.10.5) demo运行报错的问题

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -8,7 +8,7 @@
 .buildlog/
 .history
 .svn/
-
+android/.gradle
 # IntelliJ related
 *.iml
 *.ipr

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
          FlutterApplication and put your custom class here. -->
     <application
         android:usesCleartextTraffic="true"
-        android:name="io.flutter.app.FlutterApplication"
         android:label="power_image_example"
         android:icon="@mipmap/ic_launcher">
         <activity


### PR DESCRIPTION
Your Flutter application is created using an older version of the Android
embedding. It is being deprecated in favor of Android embedding v2. Follow the
steps at

https://flutter.dev/go/android-project-migration

to migrate your project. You may also pass the --ignore-deprecation flag to
ignore this check and continue with the deprecated v1 embedding. However,
the v1 Android embedding will be removed in future versions of Flutter.
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
The detected reason was:

/power_image/example/android/app/src/main/AndroidManifest.xml uses `android:name="io.flutter.app.FutterApplication"`
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Build failed due to use of deprecated Android v1 embedding.