### PR TITLE
修复因Bitmap为空导致的异常

### DIFF
--- a/android/src/main/java/com/taobao/power_image/request/PowerImageExternalRequest.java
+++ b/android/src/main/java/com/taobao/power_image/request/PowerImageExternalRequest.java
@@ -61,6 +61,10 @@ public class PowerImageExternalRequest extends PowerImageBaseRequest {
             }
             bitmap = ((BitmapDrawable) imageDrawable).getBitmap();
         }
+        if (bitmap == null) {
+            onLoadFailed(TAG + ":onLoadResult bitmap is null or bitmap has recycled");
+            return;
+        }
         // convert to ARGB_8888 for flutter decoding
         if (bitmap.getConfig() != Bitmap.Config.ARGB_8888) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && bitmap.getConfig() == Bitmap.Config.HARDWARE) {


### PR DESCRIPTION
需要对Bitmap进行判空处理