### PR TITLE
修复iOS多引擎支持

### DIFF
--- a/ios/Classes/PowerImageEngineContext.h
+++ b/ios/Classes/PowerImageEngineContext.h
@@ -1,0 +1,19 @@
+//
+//  PowerImageEngineContext.h
+//  power_image
+//
+//  Created by 杨正灿 on 2023/10/9.
+//
+
+#import <Flutter/Flutter.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PowerImageEngineContext: NSObject<FlutterStreamHandler>
+@property (nonatomic, strong) NSObject<FlutterTextureRegistry>* pluginRegistry;
+- (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar;
+- (void)onDetached;
+- (void)sendImageStateEvent:(NSMutableDictionary *)event success:(BOOL)success;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Classes/PowerImageEngineContext.m
+++ b/ios/Classes/PowerImageEngineContext.m
@@ -1,0 +1,109 @@
+//
+//  PowerImageEngineContext.m
+//  power_image
+//
+//  Created by 杨正灿 on 2023/10/9.
+//
+
+#import "PowerImageEngineContext.h"
+#import "PowerImageRequestManager.h"
+
+@interface PowerImageEngineContext ()
+@property (nonatomic, copy) FlutterEventSink eventSink;
+@property (nonatomic, strong) NSMutableArray<NSMutableDictionary *> *sendQueue;
+@property (nonatomic, strong) FlutterEventChannel *eventChannel;
+@property (nonatomic, strong) FlutterMethodChannel *methodChannel;
+@property (nonatomic, strong) PowerImageRequestManager *powerImageRequestManager;
+@end
+
+@implementation PowerImageEngineContext
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        self.powerImageRequestManager = [[PowerImageRequestManager alloc] initWithEngineContext:self];
+        self.sendQueue = [[NSMutableArray alloc] init];
+    }
+    return self;
+}
+
+- (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+    self.pluginRegistry = registrar.textures;
+    self.methodChannel = [FlutterMethodChannel methodChannelWithName:@"power_image/method" binaryMessenger:[registrar messenger]];
+    __weak typeof(self) weakSelf = self;
+    [self.methodChannel setMethodCallHandler:^(FlutterMethodCall * _Nonnull call, FlutterResult  _Nonnull result) {
+        __strong typeof(self) self = weakSelf;
+        [self handleMethodCall:call result:result];
+    }];
+    
+    self.eventChannel = [FlutterEventChannel eventChannelWithName:@"power_image/event" binaryMessenger:[registrar messenger]];
+    [self.eventChannel setStreamHandler:self];
+    
+    [self.powerImageRequestManager configWithTextureRegistry:registrar.textures];
+}
+
+- (void)onDetached {
+    if (self.methodChannel != nil) {
+        [self.methodChannel setMethodCallHandler:nil];
+    }
+    
+    if (self.eventChannel != nil) {
+        [self.eventChannel setStreamHandler:nil];
+    }
+}
+
+- (void)setMyEventSkin: (FlutterEventSink) eventSkin {
+    self.eventSink = eventSkin;
+    // 当捕捉到eventSkin后, 从预回传的数据队列中一个个回传
+    for (NSMutableDictionary *sendDic in self.sendQueue) {
+        self.eventSink(sendDic);
+    }
+    // 回传完毕清空队列
+    [self.sendQueue removeAllObjects];
+}
+
+- (FlutterError* _Nullable)onListenWithArguments:(id _Nullable)arguments
+  eventSink:(FlutterEventSink)eventSink {
+    [self setMyEventSkin:eventSink];
+    return nil;
+}
+
+- (FlutterError* _Nullable)onCancelWithArguments:(id _Nullable)arguments {
+    self.eventSink = nil;
+    return nil;
+}
+
+- (void)sendImageStateEvent:(NSMutableDictionary *)event success:(BOOL)success {
+    if (!event) {
+        return;
+    }
+    
+    // 多引擎下, evenSkin获取会有延迟, 所以这里加个队列,保存所有等待回传的数据
+    if (!self.eventSink) {
+        event[@"eventName"] = @"onReceiveImageEvent";
+        event[@"success"] = @(success);
+        [self.sendQueue addObject:event];
+    } else {
+        event[@"eventName"] = @"onReceiveImageEvent";
+        event[@"success"] = @(success);
+        self.eventSink(event);
+    }
+}
+
+- (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
+    if ([@"startImageRequests" isEqualToString:call.method]) {
+        NSArray *arguments = call.arguments;
+        NSArray *results = [self.powerImageRequestManager configRequestsWithArguments:arguments];
+        result(results);
+        [self.powerImageRequestManager startLoadingWithArguments:arguments]; // 开始图片加载任务
+    } else if ([@"releaseImageRequests" isEqualToString:call.method]) {
+        NSArray *arguments = call.arguments;
+        NSArray *results = [self.powerImageRequestManager releaseRequestsWithArguments:arguments];
+        result(results);
+    } else {
+        result(FlutterMethodNotImplemented);
+    }
+}
+
+@end

--- a/ios/Classes/PowerImagePlugin.h
+++ b/ios/Classes/PowerImagePlugin.h
@@ -1,6 +1,6 @@
 #import <Flutter/Flutter.h>
 
-@interface PowerImagePlugin : NSObject<FlutterPlugin, FlutterStreamHandler>
+@interface PowerImagePlugin : NSObject<FlutterPlugin>
 + (instancetype)sharedInstance;
-- (void)sendImageStateEvent:(NSMutableDictionary *)event success:(BOOL)success;
+- (void)detachForRegistrar:(NSObject<FlutterTextureRegistry>*)registry;
 @end

--- a/ios/Classes/Texture/PowerImageTexture.m
+++ b/ios/Classes/Texture/PowerImageTexture.m
@@ -56,11 +56,11 @@
     CGSize imageSize = [self _calculateTextureSizeWithRequestSize:size image:image];
     
     CVReturn status = CVPixelBufferCreate(kCFAllocatorDefault,
-                                          imageSize.width,
-                                          imageSize.height,
-                                          kCVPixelFormatType_32BGRA,
-                                          (__bridge CFDictionaryRef) options,
-                                          &pxbuffer);
+     imageSize.width,
+     imageSize.height,
+     kCVPixelFormatType_32BGRA,
+     (__bridge CFDictionaryRef) options,
+     &pxbuffer);
     
     NSParameterAssert(status == kCVReturnSuccess && pxbuffer != NULL);
     
@@ -73,14 +73,14 @@
     
     CGColorSpaceRef rgbColorSpace = CGColorSpaceCreateDeviceRGB();
     CGContextRef context = CGBitmapContextCreate(pxdata, imageSize.width,
-                                                 imageSize.height, 8, CVPixelBufferGetBytesPerRow(pxbuffer), rgbColorSpace,
-                                                 kCGBitmapByteOrder32Host | kCGImageAlphaPremultipliedFirst);
+            imageSize.height, 8, CVPixelBufferGetBytesPerRow(pxbuffer), rgbColorSpace,
+            kCGBitmapByteOrder32Host | kCGImageAlphaPremultipliedFirst);
     
     
     NSParameterAssert(context);
     
     CGContextDrawImage(context, CGRectMake(0, 0, imageSize.width,
-                                           imageSize.height), image);
+      imageSize.height), image);
     CGColorSpaceRelease(rgbColorSpace);
     CGContextRelease(context);
     

--- a/ios/Classes/request/PowerImageBaseRequest.h
+++ b/ios/Classes/request/PowerImageBaseRequest.h
@@ -8,6 +8,7 @@
 #import <Foundation/Foundation.h>
 #import "PowerImageRequestConfig.h"
 #import "PowerImageLoader.h"
+#import "PowerImageEngineContext.h"
 
 static NSString * const PowerImageRequestStateInitializeSucceed = @"initializeSucceed";
 static NSString * const PowerImageRequestStateInitializeFailed = @"initializeFailed";
@@ -25,7 +26,7 @@ static NSString * const PowerImageRequestRenderTypeTexture = @"texture";
 @property (nonatomic, copy) NSString *imageTaskState;
 
 
-- (instancetype)initWithArguments:(NSDictionary *)arguments;
+- (instancetype)initWithEngineContext:(PowerImageEngineContext *)context arguments:(NSDictionary *)arguments;
 
 - (BOOL)configTask;
 

--- a/ios/Classes/request/PowerImageBaseRequest.m
+++ b/ios/Classes/request/PowerImageBaseRequest.m
@@ -9,18 +9,22 @@
 #import "PowerImageDispatcher.h"
 #import "PowerImagePlugin.h"
 #import "PowerFlutterMultiFrameImage.h"
+#import "PowerImageRequestManager.h"
+
 
 @interface PowerImageBaseRequest()
 
 @property (nonatomic, strong) PowerImageResult *result;
+@property (nonatomic, strong) PowerImageEngineContext *engineContext;
 
 @end
 
 @implementation PowerImageBaseRequest
 
-- (instancetype)initWithArguments:(NSDictionary *)arguments {
+- (instancetype)initWithEngineContext:(PowerImageEngineContext *)context arguments:(NSDictionary *)arguments {
     self = [super init];
     if (self) {
+        self.engineContext = context;
         _uniqueKey = arguments[@"uniqueKey"];
         _imageRequestConfig = [PowerImageRequestConfig requestConfigWithArguments:arguments];
     }
@@ -70,7 +74,7 @@
     [[PowerImageDispatcher sharedInstance] runOnMainThread:^{
        __strong typeof(self) self = weakSelf;
        self.imageTaskState = PowerImageRequestStateLoadSucceed;
-       [[PowerImagePlugin sharedInstance] sendImageStateEvent:[self encode] success:YES];
+        [self.engineContext sendImageStateEvent:[self encode] success:YES];
     }];
 }
 
@@ -81,7 +85,7 @@
         self.imageTaskState = PowerImageRequestStateLoadFailed;
         NSMutableDictionary *event = [self encode];
         event[@"errMsg"] = errMsg;
-        [[PowerImagePlugin sharedInstance] sendImageStateEvent:event success:NO];
+        [self.engineContext sendImageStateEvent:event success:NO];
     }];
 }
 

--- a/ios/Classes/request/PowerImageRequestManager.h
+++ b/ios/Classes/request/PowerImageRequestManager.h
@@ -7,10 +7,12 @@
 
 #import <Foundation/Foundation.h>
 #import <Flutter/Flutter.h>
+#import "PowerImageEngineContext.h"
 
 
 @interface PowerImageRequestManager : NSObject
-+ (instancetype)sharedInstance;
+
+- (instancetype)initWithEngineContext:(PowerImageEngineContext *)context;
 
 - (void)configWithTextureRegistry:(id<FlutterTextureRegistry>)textureRegistry;
 

--- a/ios/Classes/request/PowerImageRequestManager.m
+++ b/ios/Classes/request/PowerImageRequestManager.m
@@ -11,29 +11,21 @@
 #import "PowerImageTextureRequest.h"
 #import "PowerImageExternalRequest.h"
 
+
 @interface PowerImageRequestManager ()
 
 @property (nonatomic, strong) NSMutableDictionary <NSString *, PowerImageBaseRequest *> * requests;
 @property (nonatomic, weak) id<FlutterTextureRegistry> textureRegistry;
+@property (nonatomic, strong) PowerImageEngineContext *engineContext;
 
 @end
 
 @implementation PowerImageRequestManager
 
-
-+ (instancetype)sharedInstance {
-    static PowerImageRequestManager *instance;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        instance = [[PowerImageRequestManager alloc] init];
-    });
-    return instance;
-}
-
-- (instancetype)init
-{
+- (instancetype)initWithEngineContext:(PowerImageEngineContext *)context {
     self = [super init];
     if (self) {
+        self.engineContext = context;
         _requests = [[NSMutableDictionary alloc] init];
     }
     return self;
@@ -54,9 +46,9 @@
         NSString *renderType = [self _renderingType:arguments];
         PowerImageBaseRequest *request;
         if ([renderType isEqualToString:PowerImageRequestRenderTypeExternal]) {
-            request = [[PowerImageExternalRequest alloc] initWithArguments:arguments];
+            request = [[PowerImageExternalRequest alloc] initWithEngineContext:self.engineContext arguments:arguments];
         }else if ([renderType isEqualToString:PowerImageRequestRenderTypeTexture]) {
-            request = [[PowerImageTextureRequest alloc] initWithArguments:arguments textureRegistry:self.textureRegistry];
+            request = [[PowerImageTextureRequest alloc] initWithEngineContext:self.engineContext arguments:arguments textureRegistry: self.textureRegistry];
         }else {
             continue;
         }

--- a/ios/Classes/request/PowerImageTextureRequest.h
+++ b/ios/Classes/request/PowerImageTextureRequest.h
@@ -11,8 +11,7 @@
 
 
 @interface PowerImageTextureRequest : PowerImageBaseRequest
-- (instancetype)initWithArguments:(NSDictionary *)arguments textureRegistry:(id<FlutterTextureRegistry>)textureRegistry;
-
+- (instancetype)initWithEngineContext:(PowerImageEngineContext *)context arguments:(NSDictionary *)arguments textureRegistry:(id<FlutterTextureRegistry>)textureRegistry;
 
 @end
 

--- a/ios/Classes/request/PowerImageTextureRequest.m
+++ b/ios/Classes/request/PowerImageTextureRequest.m
@@ -25,8 +25,8 @@
 
 @implementation PowerImageTextureRequest
 
-- (instancetype)initWithArguments:(NSDictionary *)arguments textureRegistry:(id<FlutterTextureRegistry>)textureRegistry {
-    self = [super initWithArguments:arguments];
+- (instancetype)initWithEngineContext:(PowerImageEngineContext *)context arguments:(NSDictionary *)arguments textureRegistry:(id<FlutterTextureRegistry>)textureRegistry {
+    self = [super initWithEngineContext:context arguments:arguments];
     if (self) {
         _textureRegistry = textureRegistry;
         _isStopped = NO;


### PR DESCRIPTION
根据 大佬@MeandNi 在https://github.com/alibaba/power_image/pull/38 中修复Android侧多引擎的思路，仿写的iOS支持多引擎。
差别在于，在iOS中

(FlutterError* _Nullable)onListenWithArguments:(id _Nullable)arguments
eventSink:(FlutterEventSink)eventSink {}
回调时机有可能会在图片数据回调之后， 导致Flutter侧无法接受到图片信息。
所以这边新增了个NSMutableArray<NSMutableDictionary *> *sendQueue;
用于保存在eventSkin生成前收到的所有图片信息，生成后重新发送并清空。